### PR TITLE
Add missing targetLabels to serviceMonitor

### DIFF
--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -128,6 +128,7 @@ customLabels: {}
 serviceMonitor:
   create: false
   additionalLabels: {}
+  targetLabels: []
   honorLabels: false
   scrapeTimeout: 10s
   interval: 15s


### PR DESCRIPTION
serviceMonitor object refers to targetLabels, which does not exist in values.yaml. No harm there, but it should be added to values.yaml with its default empty slice value